### PR TITLE
FINI-435: Convention for the string delimiter in JS

### DIFF
--- a/Extensions/ShapeTracing/Startup.cs
+++ b/Extensions/ShapeTracing/Startup.cs
@@ -5,9 +5,9 @@ using OrchardCore.Modules;
 namespace Lombiq.HelpfulExtensions.Extensions.ShapeTracing
 {
     [Feature(FeatureIds.ShapeTracing)]
-    public class Startup
+    public class Startup : StartupBase
     {
-        public void ConfigureServices(IServiceCollection services) =>
+        public override void ConfigureServices(IServiceCollection services) =>
             services.AddScoped<IShapeDisplayEvents, ShapeTracingShapeEvents>();
     }
 }


### PR DESCRIPTION
[FINI-435](https://lombiq.atlassian.net/browse/FINI-435)