### PR TITLE
LMBQ-264: Azure Email Communication Services

### DIFF
--- a/Lombiq.HelpfulExtensions/Manifest.cs
+++ b/Lombiq.HelpfulExtensions/Manifest.cs
@@ -88,8 +88,7 @@ using static Lombiq.HelpfulExtensions.FeatureIds;
     Description = "Adds shape-based email template rendering and helpful email sending services.",
     Dependencies =
     [
-        "OrchardCore.Email",
-        "OrchardCore.Email.Smtp",
+        "OrchardCore.Email"
     ]
 )]
 


### PR DESCRIPTION
[LMBQ-264](https://lombiq.atlassian.net/browse/LMBQ-264)

The only change here is that the Emails feature doesn't need to depend on `OrchardCore.Email.Smtp`, only `OrchardCore.Email`, so that `OrchardCore.Email.Smtp` can be disabled without issues.

[LMBQ-264]: https://lombiq.atlassian.net/browse/LMBQ-264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ