### PR TITLE
OSOE-1263: Update dependencies: lucide to v1

### DIFF
--- a/Lombiq.HelpfulExtensions/libman.json
+++ b/Lombiq.HelpfulExtensions/libman.json
@@ -11,7 +11,7 @@
       "files": [ "dist/**/*", "plugins/**/*" ]
     },
     {
-      "library": "lucide@0.542.0",
+      "library": "lucide@1.7.0",
       "files": [ "dist/umd/lucide.js", "dist/umd/lucide.min.js" ]
     }
   ]

--- a/Lombiq.HelpfulExtensions/libman.json
+++ b/Lombiq.HelpfulExtensions/libman.json
@@ -11,7 +11,7 @@
       "files": [ "dist/**/*", "plugins/**/*" ]
     },
     {
-      "library": "lucide@0.542.0",
+      "library": "lucide@0.577.0",
       "files": [ "dist/umd/lucide.js", "dist/umd/lucide.min.js" ]
     }
   ]


### PR DESCRIPTION
## Summary
- merge lucide non-breaking and major update branches
- resulting lucide update to v1.7.0

## Issue
- [OSOE-1263](https://lombiq.atlassian.net/browse/OSOE-1263)

[OSOE-1263]: https://lombiq.atlassian.net/browse/OSOE-1263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ