### PR TITLE
OSOE-1270: Fix MA0194 analyzer warning from Meziantou.Analyzer 3.0.61

### DIFF
--- a/Lombiq.HelpfulExtensions/Extensions/CodeGeneration/CodeGenerationDisplayDriver.cs
+++ b/Lombiq.HelpfulExtensions/Extensions/CodeGeneration/CodeGenerationDisplayDriver.cs
@@ -176,7 +176,9 @@ public sealed class CodeGenerationDisplayDriver : ContentTypeDefinitionDisplayDr
     {
         var braceIndentation = new string(' ', indentationDepth);
         var propertyIndentation = new string(' ', indentationDepth + IndentationDepth);
-        if (jsonObject["name"] is { } name && jsonObject["value"] is { } value)
+        var nameNode = jsonObject["name"];
+        var valueNode = jsonObject["value"];
+        if (nameNode is { } name && valueNode is { } value)
         {
             var objectCodeBuilder = new StringBuilder();
             objectCodeBuilder.AppendLine(CultureInfo.InvariantCulture, $"{braceIndentation}new ListValueOption");


### PR DESCRIPTION
[OSOE-1270](https://lombiq.atlassian.net/browse/OSOE-1270)
Fixes a false-positive MA0194 warning in CodeGenerationDisplayDriver introduced by the Meziantou.Analyzer 3.0.54 to 3.0.61 update in tools/Lombiq.Analyzers. The fix extracts the two JsonObject indexer accesses into local variables so the is patterns operate on distinct symbols.

[OSOE-1270]: https://lombiq.atlassian.net/browse/OSOE-1270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ