### PR TITLE
OSOE-1294: Update dependencies: Microsoft.Web.LibraryManager.Build 3.0.71 -> 3.0.114, lucide 1.17.0 -> 1.20.0; fix Meziantou.Analyzer warnings

### DIFF
--- a/Lombiq.HelpfulExtensions/Extensions/ContentSets/Models/ContentSetContentPickerField.cs
+++ b/Lombiq.HelpfulExtensions/Extensions/ContentSets/Models/ContentSetContentPickerField.cs
@@ -2,6 +2,4 @@ using OrchardCore.ContentManagement;
 
 namespace Lombiq.HelpfulExtensions.Extensions.ContentSets.Models;
 
-public class ContentSetContentPickerField : ContentField
-{
-}
+public class ContentSetContentPickerField : ContentField;

--- a/Lombiq.HelpfulExtensions/Lombiq.HelpfulExtensions.csproj
+++ b/Lombiq.HelpfulExtensions/Lombiq.HelpfulExtensions.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.114" />
     <PackageReference Include="OrchardCore.Autoroute" Version="2.1.0" />
     <PackageReference Include="OrchardCore.ContentFields" Version="2.1.0" />
     <PackageReference Include="OrchardCore.Contents" Version="2.1.0" />

--- a/Lombiq.HelpfulExtensions/libman.json
+++ b/Lombiq.HelpfulExtensions/libman.json
@@ -14,7 +14,7 @@
       ]
     },
     {
-      "library": "lucide@1.17.0",
+      "library": "lucide@1.20.0",
       "files": [
         "dist/umd/lucide.js",
         "dist/umd/lucide.min.js"


### PR DESCRIPTION
Covers [OSOE-1294](https://lombiq.atlassian.net/browse/OSOE-1294).

[OSOE-1294]: https://lombiq.atlassian.net/browse/OSOE-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ