### PR TITLE
OSOE-1311: Update dependencies; remove StringHelper.CreateInvariant usage

### DIFF
--- a/Lombiq.HelpfulExtensions/Views/MenuWidget.cshtml
+++ b/Lombiq.HelpfulExtensions/Views/MenuWidget.cshtml
@@ -1,8 +1,8 @@
 @using Lombiq.HelpfulExtensions.Extensions.Widgets.Constants
 @using Lombiq.HelpfulExtensions.Extensions.Widgets.Models
-@using Lombiq.HelpfulLibraries.Common.Utilities;
 @using Microsoft.AspNetCore.Http.Extensions
 @using OrchardCore.Navigation
+@using System.Globalization
 <style asp-name="font-awesome"></style>
 
 @{
@@ -13,7 +13,7 @@
     const string togglerElementName = blockName + "__toggler";
     const string dropdownElementName = blockName + "__dropdown";
 
-    var contentIdName = StringHelper.CreateInvariant($"{contentElementName}_{Guid.NewGuid()}");
+    var contentIdName = string.Create(CultureInfo.InvariantCulture, $"{contentElementName}_{Guid.NewGuid()}");
 
     var baseUri = new Uri(Context.Request.GetDisplayUrl());
 
@@ -56,7 +56,7 @@
 
                     <li class="nav-item dropdown">
                         <shape type="MenuWidgetItem"
-                               prop-Id="@StringHelper.CreateInvariant($"{dropdownElementName}_{Guid.NewGuid()}")"
+                               prop-Id="@string.Create(CultureInfo.InvariantCulture, $"{dropdownElementName}_{Guid.NewGuid()}")"
                                prop-ViewModel="@viewModel"
                                prop-Item="@menuItem"
                                prop-SubMenuItems="@subMenuItems">

--- a/Lombiq.HelpfulExtensions/libman.json
+++ b/Lombiq.HelpfulExtensions/libman.json
@@ -14,14 +14,14 @@
       ]
     },
     {
-      "library": "lucide@1.27.0",
+      "library": "lucide@1.28.0",
       "files": [
         "dist/umd/lucide.js",
         "dist/umd/lucide.min.js"
       ]
     },
     {
-      "library": "simple-icons@16.27.1",
+      "library": "simple-icons@16.28.0",
       "files": [
         "icons/*.svg"
       ]


### PR DESCRIPTION
OSOE-1311.

- Merged `renovate/non-breaking-dependency-versions`.
- Replaced `StringHelper.CreateInvariant` with `string.Create(CultureInfo.InvariantCulture, ...)` since the former doesn't actually apply the invariant culture to interpolation holes; see https://github.com/meziantou/Meziantou.Analyzer/issues/1316#issuecomment-5363658245.
